### PR TITLE
scales up number of workers and scale up ci node size

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -27,8 +27,8 @@ users-version: "master"
 users-path: "users"
 disable-destroy: true
 worker-instance-type: m5d.large
-worker-count: 3
-ci-worker-instance-type: t3.large
+worker-count: 6
+ci-worker-instance-type: m5d.large
 ci-worker-count: 3
 github-client-id: "1dbe43926d46b9ded8ad"
 github-approval-count: 1


### PR DESCRIPTION
we are getting ready for production, we need more workers as we are (1)
scaling up replicas of proxy-node instances, (2) are seeing scheduling
issues due to anti-affinity rules

we have seen poor performance of concourse workers due to the CPU heavy
builds of the java apps.