### PR TITLE
Add the NL FQDN to the egress safelist.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,10 @@ global:
 httpsEgressSafelist:
 - name: hub
   fqdn: www.integration.signin.service.gov.uk
+- name: nl
+  fqdn: acc-eidas.minez.nl
+- name: stub-connector
+  fqdn: test-connector-metadata.london.verify.govsvc.uk
 
 namespaces:
 - name: verify-main


### PR DESCRIPTION
Needs to be merged with https://github.com/alphagov/verify-proxy-node/pull/264