### PR TITLE
fix DCS namespaces

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -50,21 +50,21 @@ namespaces:
   path: ci/prod
   requiredApprovalCount: 2
 
-- name: doc-checking-staging
+- name: verify-doc-checking-staging
   owner: alphagov
   repository: doc-checking
   branch: master
   path: ci/staging
   permittedRolesRegex: "^$"
   requiredApprovalCount: 2
-- name: doc-checking-test
+- name: verify-doc-checking-test
   owner: alphagov
   repository: doc-checking
   branch: master
   path: ci/test
   permittedRolesRegex: "^$"
   requiredApprovalCount: 2
-- name: doc-checking-prod
+- name: verify-doc-checking-prod
   owner: alphagov
   repository: doc-checking
   branch: master


### PR DESCRIPTION
if you don't have a `verify-` prefix, you don't get a concourse team :(