### PR TITLE
Remove duplicate entry for stub connector.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,8 +5,6 @@ global:
     ip: "10.255.151.206"
 
 httpsEgressSafelist:
-- name: proxy-node-test
-  fqdn: test-proxy-node.london.verify.govsvc.uk
 - name: stub-connector
   fqdn: test-connector.london.verify.govsvc.uk
 - name: hub-integration


### PR DESCRIPTION
This safelist entry for the gateway is only in place for the stub
connector, and for consistency this should all live with the proxy node
chart.