### PR TITLE
restore dead namespaces

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -50,6 +50,29 @@ namespaces:
   path: ci/prod
   requiredApprovalCount: 2
 
+# legacy; needs to be deleted carefully
+- name: doc-checking-staging
+  owner: alphagov
+  repository: doc-checking
+  branch: master
+  path: ci/staging
+  permittedRolesRegex: "^$"
+  requiredApprovalCount: 2
+- name: doc-checking-test
+  owner: alphagov
+  repository: doc-checking
+  branch: master
+  path: ci/test
+  permittedRolesRegex: "^$"
+  requiredApprovalCount: 2
+- name: doc-checking-prod
+  owner: alphagov
+  repository: doc-checking
+  branch: master
+  path: ci/prod
+  permittedRolesRegex: "^$"
+  requiredApprovalCount: 2
+
 - name: verify-doc-checking-staging
   owner: alphagov
   repository: doc-checking


### PR DESCRIPTION
The pipeline operator is broken, roughly since #15 was merged.  I have
a hypothesis that this is because we removed the yaml for some
namespaces, and this broke something.  Therefore, I'm hoping to
appease the kubernetes gods and fix the pipeline operator by restoring
this legacy yaml.