### PR TITLE
BAU: Add new test integration proxy node instance

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,8 @@ httpsEgressSafelist:
   fqdn: test-connector.london.verify.govsvc.uk
 - name: hub-integration
   fqdn: www.integration.signin.service.gov.uk
+- name: test-intgegration
+  fqdn: test-integration-connector.london.verify.govsvc.uk
 - name: nl-integration
   fqdn: acc-eidas.minez.nl
 - name: dk-integration


### PR DESCRIPTION
As a result of alphagov/verify-proxy-node#242

The new instance is live at http://test-integration-connector.london.verify.govsvc.uk