### PR TITLE
Create PSN Endpoint for DCS connection

### DIFF
--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -152,3 +152,13 @@ jobs:
     params:
       terraform_source: src/terraform
       env_name: ((account-name))
+
+- name: destroy
+  plan:
+  - get: src
+    passed: [deploy-psn-vpc-endpoint]
+  - put: psn-state
+    params:
+      action: destroy
+      env_name: ((account-name))
+      terraform_source: src/terraform

--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -1,0 +1,154 @@
+---
+unpack_release: &unpack_release
+  platform: linux
+  params:
+    CLUSTER_PUBLIC_KEY:
+  run:
+    path: /bin/bash
+    args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "preparing keyring to verify release..."
+      echo "${CLUSTER_PUBLIC_KEY}" > key
+      gpg --import key
+      gpg --verify gsp/source.tar.gz.asc
+      echo "unpacking src tarball..."
+      tar -xvf gsp/source.tar.gz -C platform --strip-components=1
+  inputs:
+  - name: gsp
+  outputs:
+  - name: platform
+
+resource_types:
+- name: terraform
+  type: registry-image
+  source:
+    repository: govsvc/terraform-resource
+    tag: 0.13.0-beta.2
+- name: github
+  type: registry-image
+  source:
+    repository: ((github-resource-image))
+    tag: ((github-resource-tag))
+- name: concourse-pipeline
+  type: docker-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+    tag: "2.2.0"
+
+resources:
+- name: gsp
+  type: github-release
+  source:
+    owner: alphagov
+    repository: gsp
+    access_token: ((github-api-token))
+    release: true
+    tag_filter: gsp-v([^v].*)
+
+- name: users
+  type: github-release
+  source:
+    owner: alphagov
+    repository: gds-trusted-developers
+    access_token: ((github-api-token))
+    release: true
+
+- name: src
+  type: github
+  source:
+    uri: https://github.com/alphagov/verify-cluster-config.git
+    branch: master
+    organization: alphagov
+    repository: verify-cluster-config
+    github_api_token: ((github-api-token))
+    approvers: ((github-approvers))
+    required_approval_count: 2
+    commit_verification_keys: ((trusted-developer-keys))
+
+- name: psn-state
+  type: terraform
+  source:
+    env_name: ((account-name))
+    backend_type: s3
+    backend_config:
+      bucket: cd-gsp-private-qndvvc
+      region: eu-west-2
+      key: psn-cluster-((cluster-name)).tfstate
+    vars:
+      aws_account_role_arn: ((account-role-arn))
+      gsp_cluster_state_bucket_name: cd-gsp-private-qndvvc
+      gsp_cluster_state_bucket_key: cluster-((cluster-name)).tfstate
+      workspace_name: ((account-name))
+      vpc_endpoint: ((psn-vpc-endpoint))
+
+- name: task-toolbox
+  type: docker-image
+  source:
+    repository: govsvc/task-toolbox
+    tag: latest
+
+- name: pipeline
+  type: concourse-pipeline
+  source:
+    teams:
+    - name: gsp
+      username: gsp
+      password: ((readonly_local_user_password))
+
+jobs:
+- name: update
+  plan:
+  - get: src
+    trigger: true
+  - get: task-toolbox
+  - get: gsp
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: users
+    trigger: true
+
+  - task: unpack-gsp-release
+    image: task-toolbox
+    config: *unpack_release
+    params:
+      CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
+
+  - task: generate-trusted-contributors
+    image: task-toolbox
+    file: platform/pipelines/tasks/generate-trusted-contributors.yaml
+    params:
+      ACCOUNT_NAME: ((account-name))
+      CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
+
+  - put: pipeline
+    params:
+      pipelines:
+      - name: ((concourse-pipeline-name))
+        team: ((concourse-team))
+        config_file: src/ci/psn.yaml
+        vars_files:
+        - trusted-contributors/github.vars.yaml
+        - trusted-contributors/keys.vars.yaml
+        vars:
+          account-name: ((account-name))
+          account-role-arn: ((account-role-arn))
+          cluster-name: ((cluster-name))
+          github-approval-count: 0
+          github-resource-image: ((github-resource-image))
+          github-resource-tag: ((github-resource-tag))
+          concourse-pipeline-name: ((concourse-pipeline-name))
+          concourse-team: ((concourse-team))
+
+- name: deploy-psn-vpc-endpoint
+  plan:
+  - get: src
+    passed: [update]
+    trigger: true
+  - put: psn-state
+    params:
+      terraform_source: src/terraform
+      env_name: ((account-name))

--- a/hack/set-pipeline-vars.sh
+++ b/hack/set-pipeline-vars.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+: "${CLUSTER_NAME:?}"
+PIPELINE_NAME="${PIPELINE_NAME:-vpc-endpoint}"
+FLY_BIN="${FLY_BIN:-fly}"
+
+$FLY_BIN -t cd-gsp sync
+
+$FLY_BIN -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
+	--config "ci/psn.yaml" \
+  --var "account-name=${CLUSTER_NAME}" \
+  --var "cluster-name=${CLUSTER_NAME}" \
+  --var "concourse-pipeline-name=${PIPELINE_NAME}" \
+  --var "concourse-team=gsp" \
+  --yaml-var "github-approvers=[noone]" \
+  --var "github-resource-image=govsvc/concourse-github-resource" \
+  --var "github-resource-tag=gsp-v1.0.44" \
+  --yaml-var "trusted-developer-keys=[]" \
+	--check-creds "$@"
+
+$FLY_BIN -t cd-gsp expose-pipeline -p "${PIPELINE_NAME}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,6 +49,4 @@ module "psn" {
   vpc_endpoint       = "${var.vpc_endpoint}"
   subnet_ids         = ["${data.terraform_remote_state.gsp_cluster.subnet_ids[0]}", "${data.terraform_remote_state.gsp_cluster.subnet_ids[1]}"]
   security_group_ids = ["${data.terraform_remote_state.gsp_cluster.worker_security_group_id}"]
-  r53_zone_id        = "${data.terraform_remote_state.gsp_cluster.r53_zone_id}"
-  r53_zone_name      = "${data.terraform_remote_state.gsp_cluster.r53_zone_name}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,54 @@
+variable "gsp_cluster_state_bucket_name" {
+  type = "string"
+}
+
+variable "gsp_cluster_state_bucket_key" {
+  type = "string"
+}
+
+variable "workspace_name" {
+  type = "string"
+}
+
+variable "vpc_endpoint" {
+  type = "string"
+}
+
+variable "aws_account_role_arn" {
+  type = "string"
+}
+
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "${var.aws_account_role_arn}"
+  }
+}
+
+
+data "terraform_remote_state" "gsp_cluster" {
+  backend = "s3"
+
+  config = {
+    bucket = "${var.gsp_cluster_state_bucket_name}"
+    key    = "${var.gsp_cluster_state_bucket_key}"
+    region = "eu-west-2"
+  }
+
+  workspace = "${var.workspace_name}"
+}
+
+module "psn" {
+  source             = "./modules/psn"
+  vpc_id             = "${data.terraform_remote_state.gsp_cluster.vpc_id}"
+  vpc_endpoint       = "${var.vpc_endpoint}"
+  subnet_ids         = ["${data.terraform_remote_state.gsp_cluster.subnet_ids}"]
+  security_group_ids = ["${data.terraform_remote_state.gsp_cluster.worker_security_group_id}"]
+  r53_zone_id        = "${data.terraform_remote_state.gsp_cluster.r53_zone_id}"
+  r53_zone_name      = "${data.terraform_remote_state.gsp_cluster.r53_zone_name}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,7 +47,7 @@ module "psn" {
   source             = "./modules/psn"
   vpc_id             = "${data.terraform_remote_state.gsp_cluster.vpc_id}"
   vpc_endpoint       = "${var.vpc_endpoint}"
-  subnet_ids         = ["${data.terraform_remote_state.gsp_cluster.subnet_ids}"]
+  subnet_ids         = ["${data.terraform_remote_state.gsp_cluster.subnet_ids[0]}", "${data.terraform_remote_state.gsp_cluster.subnet_ids[1]}"]
   security_group_ids = ["${data.terraform_remote_state.gsp_cluster.worker_security_group_id}"]
   r53_zone_id        = "${data.terraform_remote_state.gsp_cluster.r53_zone_id}"
   r53_zone_name      = "${data.terraform_remote_state.gsp_cluster.r53_zone_name}"

--- a/terraform/modules/psn/main.tf
+++ b/terraform/modules/psn/main.tf
@@ -1,0 +1,48 @@
+variable "vpc_id" {
+  type        = "string"
+  description = "The ID of the VPC in which the endpoint will be used."
+}
+
+variable "vpc_endpoint" {
+  type        = "string"
+  description = "The service name, in the form com.amazonaws.region.service for AWS services."
+}
+
+variable "subnet_ids" {
+  type        = "list"
+  description = "The ID of one or more subnets in which to create a network interface for the endpoint."
+}
+
+variable "security_group_ids" {
+  type        = "list"
+  description = "The ID of one or more security groups to associate with the network interface."
+}
+
+variable "r53_zone_id" {
+  type        = "string"
+  description = "The ID of the hosted zone to contain this record."
+}
+
+variable "r53_zone_name" {
+  type        = "string"
+  description = "The name of the record."
+}
+
+resource "aws_vpc_endpoint" "psn_service" {
+  vpc_id            = "${var.vpc_id}"
+  service_name      = "${var.vpc_endpoint}"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = ["${var.security_group_ids}"]
+
+  subnet_ids          = ["${var.subnet_ids}"]
+  private_dns_enabled = false
+}
+
+resource "aws_route53_record" "psn_service" {
+  zone_id = "${var.r53_zone_id}"
+  name    = "psn.${var.r53_zone_name}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${lookup(aws_vpc_endpoint.psn_service.dns_entry[0], "dns_name")}"]
+}


### PR DESCRIPTION
## What

The Verify cluster needs to have a VPC endpoint available for the teams
to use PSN. This isn't standard core GSP requirement, therefore the
snowflake is to be living with the verify cluster config.

We will need to apply the module. Instead of just going into this module
directory, we will be calling the module from different terraform file,
which should allow us to nicely separate the potentially sensitive data
from the "logic".

We need to add some extra functionality into the GSP cluster that is
very DCS specific. It needs to be separated out from the GSP logic as it
will not be applied across the board.

We're adding the hack script as:

- The Concourse pipeline doesn't have these variables set by Concourse
  from the start, so we need to specify them. Like in `alphagov/gsp`, add
  a `hack/` script to set pipeline vars.
- The multi-tenant Concourse is v4, and the GSP Concourses are v5.
- Fly does not like mismatching major versions.
- I have got around needing to `fly` in both Concourses by downloading
  v4's `fly` and using it as `fly4`.
- If `FLY_BIN` is unset, use `fly`.

As it turns out, Cloud Fundamentals the company providing PSNaaS has set
us up with two AZs available for our VPC endpoint. We are running the
GSP cluster across three AZs, meaning we have to do some work to pick
the correct two AZs (`2a` and `2b`) from the Cluster state.

This is very fragile, and has no guarantees to be indefinitely
working... We could be looking at validating the AZs across the
accounts, as AWS likes to mix the names for the AZs up a little.

For further reading:

https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html
https://www.terraform.io/docs/providers/aws/d/availability_zone.html
https://www.terraform.io/docs/providers/aws/d/subnet_ids.html

We believe that the endpoint could be sensitive piece of information. We
don't feel comfortable exposing it to the wild with the route53
record... Although, we trust that the provider will only approve
connections based on the data we provide.

Instead, we can setup a private hosted zone, for our VPC and work with
that. There is no reason, the private hosted zone couldn't live with the
rest of GSP core. In order to unblock ourselves, we're willing to have
it as part of the snowflake.

## How to review

- Sanity check
- See the division of Subnets
- Attempt to set the pipeline yourself
- See the green pipeline in sandbox / Run the pipeline yourself

---

Co-authored-by: Rafal Proszowski <rafal.proszowski@digital.cabinet-office.gov.uk>
Co-authored-by: Issy Long <isabell.long@digital.cabinet-office.gov.uk>
Co-authored-by: Daniel Blair <daniel.blair@digital.cabinet-office.gov.uk>