### PR TITLE
OGD-279: Remove 1 Eye on doc-checking build.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -107,4 +107,4 @@ namespaces:
   branch: OGD-253/make-pipeline-push-to-harbour
   path: ci/build
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 1
+  requiredApprovalCount: 0

--- a/values.yaml
+++ b/values.yaml
@@ -107,4 +107,4 @@ namespaces:
   branch: OGD-253/make-pipeline-push-to-harbour
   path: ci/build
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
+  requiredApprovalCount: 1


### PR DESCRIPTION
- Not yet being used for production, testing only.

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>