### PR TITLE
Give the PSN VPC endpoint its own security group

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,9 +44,9 @@ data "terraform_remote_state" "gsp_cluster" {
 }
 
 module "psn" {
-  source             = "./modules/psn"
-  vpc_id             = "${data.terraform_remote_state.gsp_cluster.vpc_id}"
-  vpc_endpoint       = "${var.vpc_endpoint}"
-  subnet_ids         = ["${data.terraform_remote_state.gsp_cluster.subnet_ids[0]}", "${data.terraform_remote_state.gsp_cluster.subnet_ids[1]}"]
-  security_group_ids = ["${data.terraform_remote_state.gsp_cluster.worker_security_group_id}"]
+  source            = "./modules/psn"
+  vpc_id            = "${data.terraform_remote_state.gsp_cluster.vpc_id}"
+  vpc_endpoint      = "${var.vpc_endpoint}"
+  subnet_ids        = ["${data.terraform_remote_state.gsp_cluster.subnet_ids[0]}", "${data.terraform_remote_state.gsp_cluster.subnet_ids[1]}"]
+  security_group_id = "${data.terraform_remote_state.gsp_cluster.worker_security_group_id}"
 }

--- a/terraform/modules/psn/main.tf
+++ b/terraform/modules/psn/main.tf
@@ -13,9 +13,9 @@ variable "subnet_ids" {
   description = "The ID of one or more subnets in which to create a network interface for the endpoint."
 }
 
-variable "security_group_ids" {
+variable "security_group_id" {
   type        = "list"
-  description = "The ID of one or more security groups to associate with the network interface."
+  description = "The security group to allow access to the PSN VPC Endpoint."
 }
 
 resource "aws_vpc_endpoint" "psn_service" {
@@ -23,10 +23,37 @@ resource "aws_vpc_endpoint" "psn_service" {
   service_name      = "${var.vpc_endpoint}"
   vpc_endpoint_type = "Interface"
 
-  security_group_ids = ["${var.security_group_ids}"]
+  security_group_ids = ["${aws_security_group.psn_endpoint.id}"]
 
   subnet_ids          = ["${var.subnet_ids}"]
   private_dns_enabled = false
+}
+
+resource "aws_security_group" "psn_endpoint" {
+  name        = "psn-endpoint"
+  description = "The PSN VPC Endpoint"
+}
+
+resource "aws_security_group_rule" "psn_ingress_from_worker" {
+  security_group_id = "${aws_security_group.psn_endpoint.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 3128
+  to_port   = 3128
+
+  source_security_group_id = "${var.security_group_id}"
+}
+
+resource "aws_security_group_rule" "worker_egress_to_psn" {
+  security_group_id = "${var.security_group_id}"
+
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 3128
+  to_port   = 3128
+
+  source_security_group_id = "${aws_security_group.psn_endpoint.id}"
 }
 
 resource "aws_route53_zone" "private" {
@@ -48,8 +75,8 @@ resource "aws_route53_record" "psn_service" {
 resource "aws_route53_record" "psn_regioned_service" {
   count   = 2
   zone_id = "${aws_route53_zone.private.zone_id}"
-  name    = "psn.${count.index+1}.${aws_route53_zone.private.name}"
+  name    = "psn.${count.index + 1}.${aws_route53_zone.private.name}"
   type    = "CNAME"
   ttl     = "300"
-  records = ["${lookup(aws_vpc_endpoint.psn_service.dns_entry[count.index+1], "dns_name")}"]
+  records = ["${lookup(aws_vpc_endpoint.psn_service.dns_entry[count.index + 1], "dns_name")}"]
 }


### PR DESCRIPTION
Currently, the PSN VPC endpoint is in the "worker" security group,
which is good to get us going but is possibly too permissive.  We only
need access to a single port on the VPC endpoint.

This commit gives the VPC endpoint its own security group and grants
access from the worker security group to the VPC endpoint security
group on port 3128.

This is completely untested; I don't know if the syntax is even valid.  I mainly want to have a conversation about this.