### PR TITLE
Enable NLB in Verify's cluster

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -29,4 +29,4 @@ ci-worker-instance-type: m5d.large
 ci-worker-count: 3
 github-approval-count: 1
 config-approval-count: 1
-enable-nlb: false
+enable-nlb: 1


### PR DESCRIPTION
Add an NLB so it's possible for tenants to do their own mTLS.