### PR TITLE
remove legacy namespaces

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -59,29 +59,6 @@ namespaces:
   path: ci/prod
   requiredApprovalCount: 2
 
-# legacy; needs to be deleted carefully
-- name: doc-checking-staging
-  owner: alphagov
-  repository: doc-checking
-  branch: OGD-253/make-pipeline-push-to-harbour
-  path: ci/staging
-  permittedRolesRegex: "^$"
-  requiredApprovalCount: 0
-- name: doc-checking-test
-  owner: alphagov
-  repository: doc-checking
-  branch: master
-  path: ci/test
-  permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
-- name: doc-checking-prod
-  owner: alphagov
-  repository: doc-checking
-  branch: master
-  path: ci/prod
-  permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
-
 - name: verify-doc-checking-staging
   owner: alphagov
   repository: doc-checking


### PR DESCRIPTION
I'm admin today so I can deploy this and delete any underlying
resources we need to delete