### PR TITLE
Add a CNAME record for dcs-dev.verify pointing at the NLB

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,7 +30,6 @@ provider "aws" {
   }
 }
 
-
 data "terraform_remote_state" "gsp_cluster" {
   backend = "s3"
 
@@ -49,4 +48,13 @@ module "psn" {
   vpc_endpoint       = "${var.vpc_endpoint}"
   subnet_ids         = ["${data.terraform_remote_state.gsp_cluster.subnet_ids[0]}", "${data.terraform_remote_state.gsp_cluster.subnet_ids[1]}"]
   security_group_ids = ["${data.terraform_remote_state.gsp_cluster.worker_security_group_id}"]
+}
+
+resource "aws_route53_record" "dcs_dev" {
+  zone_id = "${data.terraform_remote_state.gsp_cluster.r53_zone_id}"
+  name    = "dcs-dev.${data.terraform_remote_state.gsp_cluster.cluster_domain}"
+  type    = "CNAME"
+  ttl     = 3600
+
+  records = ["nlb.${data.terraform_remote_state.gsp_cluster.cluster_domain}"]
 }


### PR DESCRIPTION
- The DCS team need this for testing their environments now the mTLS
  work is done.
- This is snowflaked in the same way as the PSN stuff.

Co-authored-by: Daniel Blair <daniel.blair@digital.cabinet-office.gov.uk>

This depends on https://github.com/alphagov/gsp/pull/361 being released, which it isn't yet due to problems with the sandbox pipeline.