### PR TITLE
scale up workers

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -24,7 +24,7 @@ users-version: "master"
 users-path: "users"
 disable-destroy: true
 worker-instance-type: m5d.large
-worker-count: 6
+worker-count: 9
 ci-worker-instance-type: m5d.large
 ci-worker-count: 3
 github-approval-count: 1


### PR DESCRIPTION
we're hitting resource limits - CPU, memory and pod limits.  This has
meant that istio-pilot is unable to schedule pods.