### PR TITLE
Add more workers and resize the boxes

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -25,8 +25,8 @@ users-path: "users"
 disable-destroy: true
 worker-instance-type: m5d.large
 worker-count: 9
-ci-worker-instance-type: m5d.large
-ci-worker-count: 3
+ci-worker-instance-type: m5d.xlarge
+ci-worker-count: 6
 github-approval-count: 1
 config-approval-count: 1
 enable-nlb: 1

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,12 @@ global:
     enabled: true
     ip: "10.255.151.206"
 
+concourse:
+  web:
+    replicas: 3
+  worker:
+    replicas: 6
+
 # whitelist of services external from the cluster
 # that we allow egress traffic to.
 # see https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry


### PR DESCRIPTION
## What

We are experiencing issues with Concourse in particular. Jobs are slow,
things are not being scheduled properly or in timely fashion.

Adding workers, should ensure spread of the load, and resizing the
instances should provide it with more compute power to perform certain
jobs faster.

One thing to watch out for, is that we believe the concourse workers,
which are in fact containers running on the nodes are magically sizing
up to the fullest potential. We should perhaps look into if that's true
and figure out if the CI AWS instances are being fully used at the peak
times.

## How to review

- Sanity check
- Make sure my changes to `values.yaml` file are appropriate and will work...