### PR TITLE
Add OCSP to http egress safelist

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,10 @@ httpsEgressSafelist:
 - name: sqs-eu-west-2
   fqdn: sqs.eu-west-2.amazonaws.com
 
+httpEgressSafelist:
+- name: ocsp
+  fqdn: std-ocsp.trustwise.com
+
 namespaces:
 - name: verify-main
 


### PR DESCRIPTION
DCS applications want to talk to OCSP on the Internet. The Online Certificate Status Protocol (OCSP) is an Internet protocol used for obtaining the revocation status of an X.509 digital certificate.

Author: @adityapahuja