### PR TITLE
BAU - Build doc-checking-build from master

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -83,7 +83,7 @@ namespaces:
 - name: verify-doc-checking-build
   owner: alphagov
   repository: doc-checking
-  branch: OGD-253/make-pipeline-push-to-harbour
+  branch: master
   path: ci/build
   permittedRolesRegex: "^$"
   requiredApprovalCount: 0


### PR DESCRIPTION
- The pipeline is in a better place now that we should start building from master
so we don't get out of sync.