### PR TITLE
Deploy VMC to Sandbox from a separate pipeline than the Verify cluster

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ namespaces:
   owner: alphagov
   repository: verify-metadata-controller
   branch: master
-  path: ci
+  path: ci/verify
   permittedRolesRegex: "^$"
   requiredApprovalCount: 2
   scope: cluster


### PR DESCRIPTION
We don't want the Sandbox instance to publish real releases to Github. There need to be two pipelines, just like for the Proxy Node.

This needs to be merged with alphagov/tech-ops-cluster-config#241 and before alphagov/verify-metadata-controller#46