### PR TITLE
Specify the correct port number for RDS Aurora Postgres

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -96,7 +96,7 @@ egressSafelist:
     addresses: ["10.0.0.0/8"]
     ports:
     - name: postgres
-      number: 5432
+      number: 3306
       protocol: TLS
     location: MESH_EXTERNAL
     resolution: NONE


### PR DESCRIPTION
- The Postgres default port of 5432 is not correct. Aurora exposes 3306
  for Postgres, which is confusingly also the MySQL port.