### PR TITLE
Fix RDS access from Istio-managed namespaces

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -97,7 +97,7 @@ egressSafelist:
     ports:
     - name: postgres
       number: 3306
-      protocol: TLS
+      protocol: TCP
     location: MESH_EXTERNAL
     resolution: NONE
 - name: ocsp


### PR DESCRIPTION
- We were seeing issues connecting to AWS RDS from Istio-managed
  namespaces such that the connection would never get to Amazon, it
  would be blocked by Istio, like:
  ```
  psql: server closed the connection unexpectedly
  This probably means the server terminated abnormally
  before or while processing the request.
  ```
- This change sets `protocol` to `TCP` instead of `TLS` so that we allow
  all traffic on port 3306 to the entire VPC subnet. Maybe we should
  clean this up in a later commit? But for now, it unblocks DCS.

Co-authored-by: Issy Long <isabell.long@digital.cabinet-office.gov.uk>
Co-authored-by: Daniel Blair <daniel.blair@digital.cabinet-office.gov.uk>