### PR TITLE
Enrol verify-main & canary into per-namespace ingress gateway.

### DIFF
--- a/config/verify-main/ingress-certificate.yaml
+++ b/config/verify-main/ingress-certificate.yaml
@@ -1,0 +1,18 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: ingress-certificate
+  namespace: verify-main
+spec:
+  secretName: istio-ingressgateway-certs
+  dnsNames:
+  - "canary.london.verify.govsvc.uk"
+  acme:
+    config:
+    - dns01:
+        provider: route53
+      domains:
+      - "canary.london.verify.govsvc.uk"
+  issuerRef:
+    name: letsencrypt-r53
+    kind: ClusterIssuer

--- a/values.yaml
+++ b/values.yaml
@@ -112,6 +112,13 @@ egressSafelist:
 
 namespaces:
 - name: verify-main
+  owner: alphagov
+  repository: verify-cluster-config
+  branch: master
+  path: config/verify-main
+  requiredApprovalCount: 2
+  ingress:
+    enabled: true
 
 - name: verify-connector-node-metadata
   owner: alphagov


### PR DESCRIPTION
Requires GSP >= 1.1.50
