### PR TITLE
Scale up workers

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -24,7 +24,7 @@ users-version: "master"
 users-path: "users"
 disable-destroy: true
 worker-instance-type: m5d.large
-worker-count: 9
+worker-count: 12
 ci-worker-instance-type: m5d.large
 ci-worker-count: 3
 github-approval-count: 1


### PR DESCRIPTION
We deployed some new stuff and so we started getting
KubeletTooManyPods alerts (hooray, see alphagov/gsp#399) so we should
probably scale up.