### PR TITLE
Remove old github-approval-count key

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -27,6 +27,5 @@ worker-instance-type: m5d.large
 worker-count: 12
 ci-worker-instance-type: m5d.large
 ci-worker-count: 3
-github-approval-count: 1
 config-approval-count: 1
 enable-nlb: 1


### PR DESCRIPTION
Was replaced with config-approval-count
See https://github.com/alphagov/gsp/pull/303