### PR TITLE
bump cluster to m5d.xlarge

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -23,7 +23,7 @@ users-repository: "gds-trusted-developers"
 users-version: "master"
 users-path: "users"
 disable-destroy: true
-worker-instance-type: m5d.large
+worker-instance-type: m5d.xlarge
 worker-count: 12
 ci-worker-instance-type: m5d.large
 ci-worker-count: 3


### PR DESCRIPTION
This bumps the worker node size to m5d.xlarge.  This is for IP address
efficiency reasons.

In detail:

 - `m5d.large` instances have a maximum of 30 IP addresses.  One is
   used by the kubelet, leaving 29 for use by pods.
 - `m5d.xlarge` instances are twice the price and have twice the IP
   addresses - they have 60 IPs, 59 for use by pods.
 - we currently run 8 DaemonSets, which consume 8 of the available IPs
   on each node.  This means that actually `m5d.large` nodes have
   space for 21 non-daemon pods, while `m5d.xlarge` nodes have space
   for 51
 - therefore, an `m5d.xlarge` instance is 2x the price but can run
   2.4x the pods

This commit bumps the instance size up.  A follow-up PR will reduce
the number of nodes to 6.

Do not merge before alphagov/gsp#580