### PR TITLE
Reduce minimum worker count per AZ by 1

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -25,7 +25,7 @@ users-path: "users"
 disable-destroy: true
 worker-instance-type: m5d.xlarge
 worker-count: 0
-minimum-workers-per-az-count: 4
+minimum-workers-per-az-count: 3
 maximum-workers-per-az-count: 6
 ci-worker-instance-type: m5d.large
 ci-worker-count: 3


### PR DESCRIPTION
When the image type was changed from m5d.large to m5d.xlarge we did not reduce
the number of nodes. We can probably reduce the minimum and see what the
cluster autoscaler comes up with for desired number.