### PR TITLE
Change instance type.

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -26,7 +26,7 @@ disable-destroy: true
 worker-instance-type: m5d.xlarge
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 6
-ci-worker-instance-type: m5d.xlarge
+ci-worker-instance-type: m5.xlarge
 ci-worker-count: 3
 config-approval-count: 1
 enable-nlb: 1


### PR DESCRIPTION
The 'd' types aren't useful in EKS land as the local disk gets replaced by
the EBS volume anyway.

Before merge:

- [x] Terraform upgrade rolled out to all clusters
- [x] `Deploy` job paused in all pipelines