### PR TITLE
PSN endpoint: Remove plan_only

### DIFF
--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -164,7 +164,6 @@ jobs:
     params:
       terraform_source: src/terraform
       env_name: ((account-name))
-      plan_only: true
 
 - name: destroy
   plan:


### PR DESCRIPTION
Terraform upgrade has resulted in no changes to state