### PR TITLE
Temporarily disable ingress for DCS prod

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -146,7 +146,7 @@ namespaces:
   permittedRolesRegex: "^$"
   requiredApprovalCount: 2
   ingress:
-    enabled: true
+    enabled: false
 - name: verify-doc-checking-build
   owner: alphagov
   repository: doc-checking


### PR DESCRIPTION
## After merge

```
gds verify k -n verify-doc-checking-prod delete horizontalpodautoscaler.autoscaling/verify-doc-checking-prod-ingressgateway \
    deployment.apps/verify-doc-checking-prod-ingressgateway \
    service/verify-doc-checking-prod-ingressgateway
```