### PR TITLE
Explicitly get the psn-state resource in the pipeline.

### DIFF
--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -208,6 +208,7 @@ jobs:
     params:
       terraform_source: src/terraform
       env_name: ((account-name))
+  - get: psn-state
   - task: generate-psn-resources
     image: task-toolbox
     timeout: 5m


### PR DESCRIPTION
Some of the outputs are missing and/or not populated. Hopefully explicitly
doing a get on the resource populates the missing data.