### PR TITLE
Use `latest` version of terraform resource in psn pipeline.

### DIFF
--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -69,7 +69,7 @@ resource_types:
   type: registry-image
   source:
     repository: govsvc/terraform-resource
-    tag: gsp-vd066e31
+    tag: latest
 - name: github
   type: registry-image
   source:


### PR DESCRIPTION
Brings it inline with the GSP deployer pipelines.