### PR TITLE
Fix network policy to allow other policies to act.

### DIFF
--- a/terraform/modules/psn/data/psn-network-policy.yaml
+++ b/terraform/modules/psn/data/psn-network-policy.yaml
@@ -19,4 +19,3 @@ spec:
       namespaceSelector: talksToPsn != 'true'
     destination:
       nets: ${psn_cidrs}
-  - action: Allow


### PR DESCRIPTION
The "Allow" action will cause calico to stop processing other rules and
allow the packet. This is not intended as other policies contain deny
rules that need to be processed after this (they have a higher "order"
value).