### PR TITLE
[DO NOT MERGE] EID-1823 Create eidas-proxy-node-build namespace

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -144,6 +144,14 @@ namespaces:
   talksToHsm: true
   ingress:
     enabled: true
+- name: eidas-proxy-node-build
+  owner: alphagov
+  repository: verify-proxy-node
+  path: ci/build
+  requiredApprovalCount: 2
+  talksToHsm: true
+  ingress:
+    enabled: true
 
 - name: verify-doc-checking-test
   owner: alphagov


### PR DESCRIPTION
Create a new `eidas-proxy-node-build` namespace on GSP Verify Cluster.
This namespace will operate on the `master` branch of the Proxy Node.

Another namespace will be added in future to support integration and production.