### PR TITLE
Enable DCS prod namespace connection to the PSN

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -161,7 +161,7 @@ namespaces:
   path: ci/prod
   permittedRolesRegex: "^$"
   requiredApprovalCount: 2
-  talksToPsn: false
+  talksToPsn: true
   ingress:
     enabled: false
 - name: verify-doc-checking-build


### PR DESCRIPTION
IA have now given approval.

We will still need to set up ServiceEntry resources and talksToPsn pod labels before anything can talk, but that happens in doc-checking.git.