### PR TITLE
remove commit_verification_keys

### DIFF
--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -109,7 +109,6 @@ resources:
     github_api_token: ((github-api-token))
     approvers: ((config-approvers))
     required_approval_count: 2
-    commit_verification_keys: ((trusted-developer-keys))
 
 - name: cluster-state
   type: terraform


### PR DESCRIPTION
The latest version of the github resource doesn't need this (since
alphagov/gsp#378).  Instead the process is to add your GPG key to
GitHub and get GitHub to verify the signature; we only need to
validate the signature on the GitHub merge commit against the GitHub
web flow key.

Note that if we can get rid of commit_verification_keys from all our
pipelines, we can also merge alphagov/gds-trusted-developers#111 so
that we no longer have to faff with GPG keys in that repository when
people join teams that commit to GSP projects.