### PR TITLE
Swap from m5d.xlarge worker nodes to m5.xlarge

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -23,7 +23,7 @@ users-repository: "gds-trusted-developers"
 users-version: "master"
 users-path: "users"
 disable-destroy: true
-worker-instance-type: m5d.xlarge
+worker-instance-type: m5.xlarge
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 6
 ci-worker-instance-type: m5.xlarge


### PR DESCRIPTION
We weren't taking advantage of the difference.

Don't merge this until https://github.com/alphagov/tech-ops-cluster-config/pull/273
has been done and we're happy with the process.