### PR TITLE
fix psn pipeline

### DIFF
--- a/ci/psn.yaml
+++ b/ci/psn.yaml
@@ -184,7 +184,6 @@ jobs:
         config_file: src/ci/psn.yaml
         vars_files:
         - trusted-contributors/github.vars.yaml
-        - trusted-contributors/keys.vars.yaml
         vars:
           account-name: ((account-name))
           account-role-arn: ((account-role-arn))


### PR DESCRIPTION
I missed this reference when doing #100, so the pipeline is broken
because it can't find keys.vars.yaml (which no longer exists).