### PR TITLE
EID-1823 Update hostname of new multi-country test stub-connector

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ egressSafelist:
     hosts:
       # Stub Connector build
       - test-connector.london.verify.govsvc.uk #legacy single country stub connector
-      - eidas-stub-connector-test.london.verify.govsvc.uk
+      - stub-connector.eidas.test.london.verify.govsvc.uk
       # Hub integration
       - www.integration.signin.service.gov.uk
     ports:


### PR DESCRIPTION
Update hostname of test stub-connector in verify cluster.
An update is safe to do as this new test instance is still being configured.