### PR TITLE
BAU: Increase required approvals for DCS build

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -193,7 +193,7 @@ namespaces:
   branch: master
   path: ci/build
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 0
+  requiredApprovalCount: 2
   ingress:
     enabled: true
 


### PR DESCRIPTION
This was at 0 but should be at 2 for the time being.