### PR TITLE
BAU: Reduce DCS required approvals from 2 to 1

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -174,7 +174,7 @@ namespaces:
   branch: master
   path: ci/test
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
+  requiredApprovalCount: 1
   ingress:
     enabled: true
 - name: verify-doc-checking-prod
@@ -183,7 +183,7 @@ namespaces:
   branch: master
   path: ci/prod
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
+  requiredApprovalCount: 1
   talksToPsn: true
   ingress:
     enabled: true
@@ -193,7 +193,7 @@ namespaces:
   branch: master
   path: ci/build
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
+  requiredApprovalCount: 1
   ingress:
     enabled: true
 - name: verify-doc-checking-integration
@@ -202,7 +202,7 @@ namespaces:
   branch: master
   path: ci/integration
   permittedRolesRegex: "^$"
-  requiredApprovalCount: 2
+  requiredApprovalCount: 1
   ingress:
     enabled: true
 


### PR DESCRIPTION
This is in accordance to an ADR that has been approved by Tom Lee (Verify) and Paul Ellis (IA)

https://github.com/alphagov/doc-checking/pull/773