### PR TITLE
BAU: remove unused 'verify-doc-checking-test'

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -167,16 +167,6 @@ namespaces:
     enabled: true
 
 # DCS namespaces
-
-- name: verify-doc-checking-test
-  owner: alphagov
-  repository: doc-checking
-  branch: master
-  path: ci/test
-  permittedRolesRegex: "^$"
-  requiredApprovalCount: 1
-  ingress:
-    enabled: true
 - name: verify-doc-checking-prod
   owner: alphagov
   repository: doc-checking


### PR DESCRIPTION
This namespace is not currently being used, and there seems to be no likelihood of us needing it in the near future. If we do, re-creating should be simple.