### PR TITLE
BAU: create new DCS integration environment

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -186,6 +186,15 @@ namespaces:
   requiredApprovalCount: 1
   ingress:
     enabled: true
+- name: verify-dcs-integration
+  owner: alphagov
+  repository: doc-checking
+  branch: master
+  path: ci/integration
+  permittedRolesRegex: "^$"
+  requiredApprovalCount: 1
+  ingress:
+    enabled: true
 - name: verify-doc-checking-integration
   owner: alphagov
   repository: doc-checking


### PR DESCRIPTION
The previous iteration (verify-doc-checking-integration) had too many characters. We are going to use a shortened version to get it deploying successfully.

Once this has been deployed, I'll create a follow-up PR to delete the old environment (and ask an RE person to do the deletion next time they assume admin powers).

This should fix the issue identified by @samcrang: https://gds.slack.com/archives/CHP6D0Q6B/p1578923334028100