### PR TITLE
BAU: remove old DCS integration environment

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -195,15 +195,6 @@ namespaces:
   requiredApprovalCount: 1
   ingress:
     enabled: true
-- name: verify-doc-checking-integration
-  owner: alphagov
-  repository: doc-checking
-  branch: master
-  path: ci/integration
-  permittedRolesRegex: "^$"
-  requiredApprovalCount: 1
-  ingress:
-    enabled: true
 
 extraPermissionsSRE:
   - apiGroups: ["verify.gov.uk"]


### PR DESCRIPTION
It's name was too long, so we had to [replace it](https://github.com/alphagov/verify-cluster-config/pull/112) with 'verify-dcs-integration' instead. This has been done, so the old one with the longer name can now be removed.

An RE person with admin permissions will be needed to delete everything currently in that namespace after this has been merged.