### PR TITLE
EID-1893: create new proxy node namespace for both production and integration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -123,6 +123,17 @@ namespaces:
   ingress:
     enabled: true
 
+# Proxy Node namespace for both the integration and production release
+- name: verify-eidas-proxy-node-deploy
+  owner: alphagov
+  repository: verify-proxy-node
+  branch: master
+  path: ci/deploy
+  requiredApprovalCount: 2
+  talksToHsm: true
+  ingress:
+    enabled: true
+
 # Proxy Node legacy (single-country) namespaces
 
 # TODO: The VMC needs to move to a legacy branch too


### PR DESCRIPTION
Create a new k8s namespace for both the integration and production release in a new namespace called verify-eidas-proxy-node-deploy

PR for the deploy directory in the verify-proxy-node: https://github.com/alphagov/verify-proxy-node/pull/479