### PR TITLE
Remove required approvals from connector-node-metadata.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -105,7 +105,7 @@ namespaces:
   repository: verify-metadata
   branch: master
   path: ci/verify
-  requiredApprovalCount: 2
+  requiredApprovalCount: 0
   ingress:
     enabled: true
 


### PR DESCRIPTION
The resources currently aren't used and the likelihood is, even if use
returns, it will not be functional or sensitive. So approvals are not
required.