### PR TITLE
Remove no-op permittedRolesRegex config

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -142,7 +142,6 @@ namespaces:
   repository: verify-metadata-controller
   branch: master
   path: ci/verify
-  permittedRolesRegex: "^$"
   requiredApprovalCount: 2
   scope: cluster
   talksToHsm: true
@@ -183,7 +182,6 @@ namespaces:
   repository: doc-checking
   branch: master
   path: ci/prod
-  permittedRolesRegex: "^$"
   requiredApprovalCount: 1
   talksToPsn: true
   ingress:
@@ -193,7 +191,6 @@ namespaces:
   repository: doc-checking
   branch: master
   path: ci/build
-  permittedRolesRegex: "^$"
   requiredApprovalCount: 1
   ingress:
     enabled: true
@@ -202,7 +199,6 @@ namespaces:
   repository: doc-checking
   branch: master
   path: ci/integration
-  permittedRolesRegex: "^$"
   requiredApprovalCount: 1
   ingress:
     enabled: true


### PR DESCRIPTION
These were all default values and the field is being removed in
https://github.com/alphagov/gsp/pull/977 anyway.