### PR TITLE
[DO NOT MERGE] :warning: use spot instances

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -25,6 +25,7 @@ users-path: "users"
 disable-destroy: true
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 6
+worker-on-demand-percentage-above-base: 50
 ci-worker-instance-type: m5.xlarge
 ci-worker-count: 3
 config-approval-count: 1


### PR DESCRIPTION
This sets `worker-on-demand-percentage-above-base` to 50.  This means
that, in each AZ, we run:

 - one guaranteed on-demand instance (the on-demand base capacity,
   which defaults to 1)
 - of the remaining instances, 50% of them will be on-demand and 50%
   will be spot instances.  The documentation doesn't actually specify
   how this is rounded - eg if there are 3 more instances, will there
   be 2 on-demand and 1 spot or 1 on-demand and 2 spot? :shrug:

Checklist before merging:

- [ ] We understand spot instance termination behaviour - are lifecycle hooks enough to drain nodes in a timely manner or do we need to subscribe to interruption notices?
- [ ] We understand recent issues with new nodes starting and pods getting scheduled but not having connectivity
