### PR TITLE
Set eks-version to current default value

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -29,3 +29,5 @@ ci-worker-instance-type: m5.xlarge
 ci-worker-count: 3
 config-approval-count: 1
 enable-nlb: 1
+eks-version: "1.14"
+worker-eks-version: "1.14"


### PR DESCRIPTION
So that we can change the default without affecting Verify