### PR TITLE
EID-1894 Allow egress to stub connector integration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,8 @@ egressSafelist:
   service:
     hosts:
       # Stub Connector
-      - test-integration-connector.london.verify.govsvc.uk
+      - test-integration-connector.london.verify.govsvc.uk #legacy single country stub connector
+      - stub-connector.eidas.integration.london.verify.govsvc.uk
       # Hub integration
       - www.integration.signin.service.gov.uk
       # HMRC integration


### PR DESCRIPTION
Add `stub-connector.eidas.integration.london.verify.govsvc.uk` to Verify cluster egress safe list