### PR TITLE
EID-1964 egress to connector on GSP DNS & gov.uk

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,8 @@ egressSafelist:
     hosts:
       # Stub Connector build
       - test-connector.london.verify.govsvc.uk #legacy single country stub connector
-      - stub-connector.eidas.test.london.verify.govsvc.uk
+      - stub-connector.test.verify-eidas-proxy-node-build.london.verify.govsvc.uk
+      - stub-connector.eidas.test.signin.service.gov.uk
       # Hub integration
       - www.integration.signin.service.gov.uk
     ports:
@@ -29,7 +30,8 @@ egressSafelist:
     hosts:
       # Stub Connector
       - test-integration-connector.london.verify.govsvc.uk #legacy single country stub connector
-      - stub-connector.eidas.integration.london.verify.govsvc.uk
+      - stub-connector.integration.verify-eidas-proxy-node-build.london.verify.govsvc.uk
+      - stub-connector.eidas.integration.signin.service.gov.uk
       # Hub integration
       - www.integration.signin.service.gov.uk
       # HMRC integration

--- a/values.yaml
+++ b/values.yaml
@@ -30,7 +30,7 @@ egressSafelist:
     hosts:
       # Stub Connector
       - test-integration-connector.london.verify.govsvc.uk #legacy single country stub connector
-      - stub-connector.integration.verify-eidas-proxy-node-build.london.verify.govsvc.uk
+      - stub-connector.integration.verify-eidas-proxy-node-deploy.london.verify.govsvc.uk
       - stub-connector.eidas.integration.signin.service.gov.uk
       # Hub integration
       - www.integration.signin.service.gov.uk


### PR DESCRIPTION
Add support for verify cluster egress to the stub connector, and also the CNAME on gov.uk to the cluster domain.

Remove the old GSP domains at `stub-connector.eidas.*.london.verify.govsvc.uk` as these have been removed from `gsp-external-dns`.

We'll remove the new GSP cluster domain name that includes the release namespace when test and integration are working.