### PR TITLE
EID-1964: Update Stub Connector metadata URL

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,8 @@ egressSafelist:
     hosts:
       # Stub Connector build
       - test-connector.london.verify.govsvc.uk #legacy single country stub connector
-      - stub-connector.eidas.test.london.verify.govsvc.uk
+      - stub-connector.test.verify-eidas-proxy-node-build.london.verify.govsvc.uk # multi-country temporary URL with namespace
+      - stub-connector.eidas.test.london.verify.govsvc.uk # multi-country custom domain
       # Hub integration
       - www.integration.signin.service.gov.uk
     ports:
@@ -29,7 +30,8 @@ egressSafelist:
     hosts:
       # Stub Connector
       - test-integration-connector.london.verify.govsvc.uk #legacy single country stub connector
-      - stub-connector.eidas.integration.london.verify.govsvc.uk
+      - stub-connector.integration.verify-eidas-proxy-node-deploy.london.verify.govsvc.uk # multi-country temporary URL with namespace
+      - stub-connector.eidas.integration.london.verify.govsvc.uk # multi-country custom domain
       # Hub integration
       - www.integration.signin.service.gov.uk
       # HMRC integration


### PR DESCRIPTION
Stub Connector URL now includes K8s namespace

The Metatron can't fetch the new Stub Connector metadata because the host is not enabled for egress
```
Error occurred while attempting to refresh metadata from
'https://stub-connector.test.verify-eidas-proxy-node-build.london.verify.govsvc.uk/ConnectorMetadata'",
"logger_name":"org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver"
```