### PR TITLE
Add custom domain terraform for eIDAS

### DIFF
--- a/ci/customdomains.yaml
+++ b/ci/customdomains.yaml
@@ -1,0 +1,161 @@
+---
+unpack_release: &unpack_release
+  platform: linux
+  params:
+    CLUSTER_PUBLIC_KEY:
+  run:
+    path: /bin/bash
+    args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "preparing keyring to verify release..."
+      echo "${CLUSTER_PUBLIC_KEY}" > key
+      gpg --import key
+      gpg --verify gsp/source.tar.gz.asc
+      echo "unpacking src tarball..."
+      tar -xvf gsp/source.tar.gz -C platform --strip-components=1
+  inputs:
+  - name: gsp
+  outputs:
+  - name: platform
+
+resource_types:
+- name: terraform
+  type: registry-image
+  source:
+    repository: govsvc/terraform-resource
+    tag: latest
+- name: github
+  type: registry-image
+  source:
+    repository: ((github-resource-image))
+    tag: ((github-resource-tag))
+- name: concourse-pipeline
+  type: docker-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+    tag: "2.2.0"
+
+resources:
+- name: gsp
+  type: github-release
+  source:
+    owner: alphagov
+    repository: gsp
+    access_token: ((github-api-token))
+    release: true
+    tag_filter: gsp-v([^v].*)
+
+- name: users
+  type: github-release
+  source:
+    owner: alphagov
+    repository: gds-trusted-developers
+    access_token: ((github-api-token))
+    release: true
+
+- name: src
+  type: github
+  source:
+    uri: https://github.com/alphagov/verify-cluster-config.git
+    branch: master
+    organization: alphagov
+    repository: verify-cluster-config
+    github_api_token: ((github-api-token))
+    approvers: ((config-approvers))
+    required_approval_count: 2
+    paths:
+    - customdomain-terraform
+    - ci/customdomains.yaml
+
+- name: customdomains-state
+  type: terraform
+  source:
+    env_name: ((account-name))
+    backend_type: s3
+    backend_config:
+      bucket: cd-gsp-private-qndvvc
+      region: eu-west-2
+      key: customdomains-cluster-((cluster-name)).tfstate
+    vars:
+      aws_account_role_arn: ((account-role-arn))
+
+- name: task-toolbox
+  type: docker-image
+  source:
+    repository: govsvc/task-toolbox
+    tag: latest
+
+- name: pipeline
+  type: concourse-pipeline
+  source:
+    teams:
+    - name: gsp
+      username: gsp
+      password: ((readonly_local_user_password))
+
+jobs:
+- name: update
+  plan:
+  - get: src
+    trigger: true
+  - get: task-toolbox
+  - get: gsp
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: users
+    trigger: true
+
+  - task: unpack-gsp-release
+    image: task-toolbox
+    config: *unpack_release
+    params:
+      CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
+
+  - task: generate-trusted-contributors
+    image: task-toolbox
+    file: platform/pipelines/tasks/generate-trusted-contributors.yaml
+    params:
+      ACCOUNT_NAME: ((account-name))
+      CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
+
+  - put: pipeline
+    params:
+      pipelines:
+      - name: ((concourse-pipeline-name))
+        team: ((concourse-team))
+        config_file: src/ci/customdomains.yaml
+        vars_files:
+        - trusted-contributors/github.vars.yaml
+        vars:
+          account-name: ((account-name))
+          account-role-arn: ((account-role-arn))
+          cluster-name: ((cluster-name))
+          config-approval-count: 0
+          github-resource-image: ((github-resource-image))
+          github-resource-tag: ((github-resource-tag))
+          concourse-pipeline-name: ((concourse-pipeline-name))
+          concourse-team: ((concourse-team))
+
+- name: deploy-customdomains
+  plan:
+  - get: src
+    passed: [update]
+    trigger: true
+  - put: customdomains-state
+    params:
+      terraform_source: src/customdomain-terraform
+      env_name: ((account-name))
+
+- name: destroy
+  plan:
+  - get: src
+    passed: [deploy-customdomains]
+  - put: customdomains-state
+    params:
+      action: destroy
+      env_name: ((account-name))
+      terraform_source: src/customdomain-terraform

--- a/customdomain-terraform/main.tf
+++ b/customdomain-terraform/main.tf
@@ -1,0 +1,116 @@
+variable "aws_account_role_arn" {
+  type = "string"
+}
+
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = var.aws_account_role_arn
+  }
+}
+
+resource "aws_route53_zone" "eidas_zone" {
+  name = "eidas.signin.service.gov.uk"
+}
+
+resource "aws_route53_record" "mw-integration" {
+  zone_id = aws_route53_zone.eidas_zone.zone_id
+  name    = "integration-mw-de.eidas.signin.service.gov.uk"
+  type    = "NS"
+  ttl     = 3600
+
+  records = [
+    "ns-81.awsdns-10.com.",
+    "ns-852.awsdns-42.net.",
+    "ns-1387.awsdns-45.org.",
+    "ns-1765.awsdns-28.co.uk."
+  ]
+}
+
+resource "aws_route53_record" "mw-staging" {
+  zone_id = aws_route53_zone.eidas_zone.zone_id
+  name    = "staging-mw-de.eidas.signin.service.gov.uk"
+  type    = "NS"
+  ttl     = 3600
+
+  records = [
+    "ns-1930.awsdns-49.co.uk.",
+    "ns-1506.awsdns-60.org.",
+    "ns-8.awsdns-01.com.",
+    "ns-969.awsdns-57.net."
+  ]
+}
+
+resource "aws_route53_record" "mw-prod" {
+  zone_id = aws_route53_zone.eidas_zone.zone_id
+  name    = "prod-mw-de.eidas.signin.service.gov.uk"
+  type    = "NS"
+  ttl     = 3600
+
+  records = [
+    "ns-1770.awsdns-29.co.uk.",
+    "ns-984.awsdns-59.net.",
+    "ns-1189.awsdns-20.org.",
+    "ns-152.awsdns-19.com."
+  ]
+}
+
+resource "aws_route53_record" "mw-alias" {
+  zone_id = aws_route53_zone.eidas_zone.zone_id
+  name    = "middleware-de.eidas.signin.service.gov.uk"
+  type    = "CNAME"
+  ttl     = 300
+
+  records = [
+    "middleware.prod-mw-de.eidas.signin.service.gov.uk."
+  ]
+}
+
+#module "staging_proxy_node" {
+#  source               = "./modules/customdomain"
+#  aws_account_role_arn = var.aws_account_role_arn
+#  zone_id              = aws_route53_zone.eidas_zone.zone_id
+#  govuk_domain         = "proxy-node.test.eidas.signin.service.gov.uk"
+#  govsvcuk_domain      = "proxy-node.test.verify-eidas-proxy-node-build.london.verify.govsvc.uk"
+#}
+#module "integration_proxy_node" {
+#  source               = "./modules/customdomain"
+#  aws_account_role_arn = var.aws_account_role_arn
+#  zone_id              = aws_route53_zone.eidas_zone.zone_id
+#  govuk_domain         = "proxy-node.integration.eidas.signin.service.gov.uk"
+#  govsvcuk_domain      = "proxy-node.integration.verify-eidas-proxy-node-deploy.london.verify.govsvc.uk"
+#}
+
+#module "prod_proxy_node" {
+#  source               = "./modules/customdomain"
+#  aws_account_role_arn = var.aws_account_role_arn
+#  zone_id              = aws_route53_zone.eidas_zone.zone_id
+#  govuk_domain         = "proxy-node.eidas.signin.service.gov.uk"
+#  govsvcuk_domain      = "proxy-node.production.verify-eidas-proxy-node-deploy.london.verify.govsvc.uk"
+#  # TODO: this will need to change per https://www.terraform.io/docs/providers/aws/r/acm_certificate.html#importing-an-existing-certificate when we get a QWAC cert issued
+#}
+
+#module "staging_stub_connector" {
+#  source               = "./modules/customdomain"
+#  aws_account_role_arn = var.aws_account_role_arn
+#  zone_id              = aws_route53_zone.eidas_zone.zone_id
+#  govuk_domain         = "stub-connector.test.eidas.signin.service.gov.uk"
+#  govsvcuk_domain      = "stub-connector.test.verify-eidas-proxy-node-build.london.verify.govsvc.uk"
+#}
+
+#module "integration_stub_connector" {
+#  source               = "./modules/customdomain"
+#  aws_account_role_arn = var.aws_account_role_arn
+#  zone_id              = aws_route53_zone.eidas_zone.zone_id
+#  govuk_domain         = "stub-connector.integration.eidas.signin.service.gov.uk"
+#  govsvcuk_domain      = "stub-connector.integration.verify-eidas-proxy-node-deploy.london.verify.govsvc.uk"
+#}
+
+output "eidas_zone_name_servers" {
+  value = aws_route53_zone.eidas_zone.name_servers
+}

--- a/customdomain-terraform/modules/customdomain/main.tf
+++ b/customdomain-terraform/modules/customdomain/main.tf
@@ -1,0 +1,91 @@
+variable "zone_id" {
+  type = "string"
+}
+
+variable "govuk_domain" {
+  type = "string"
+}
+
+variable "govsvcuk_domain" {
+  type = "string"
+}
+
+variable "aws_account_role_arn" {
+  type = "string"
+}
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = var.aws_account_role_arn
+  }
+}
+
+resource "aws_acm_certificate" "cert" {
+  provider          = aws.us-east-1
+  domain_name       = var.govuk_domain
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "cloudfront_dist" {
+  enabled          = true
+  is_ipv6_enabled  = true
+  price_class      = "PriceClass_100" # EU and NA optimised, lower cost
+  aliases          = [var.govuk_domain]
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.cert.arn
+    ssl_support_method  = "sni-only"
+  }
+
+  origin {
+    domain_name = var.govsvcuk_domain
+    origin_id   = "gsp"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "gsp"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+
+      headers = ["*"]
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+}
+
+resource "aws_route53_record" "record" {
+  zone_id = var.zone_id
+  name    = var.govuk_domain
+  type    = "CNAME"
+  ttl     = 3600
+
+  records = [aws_cloudfront_distribution.cloudfront_dist.domain_name]
+}
+


### PR DESCRIPTION
Add custom domain terraform for eIDAS
    
So proxy node can get gov.uk domains with automatically-rotated certificates
(where possible).
    
Existing middleware records copied from GOV.UK as we need to ensure they won't conflict.
    
New records commented out pending delegation from GOV.UK DNS.