### PR TITLE
custom domains: Try removing forwarding of headers

### DIFF
--- a/customdomain-terraform/modules/customdomain/main.tf
+++ b/customdomain-terraform/modules/customdomain/main.tf
@@ -86,8 +86,6 @@ resource "aws_cloudfront_distribution" "cloudfront_dist" {
       cookies {
         forward = "all"
       }
-
-      headers = ["*"]
     }
 
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
In experimenting with my CloudFront-distributed-sandbox-canary it seems turning
this off allows CloudFront to connect to our GSP origins. I suspect this is
because with it on, CloudFront will attempt to use the specified Host header,
and then get upset when GSP serves a certificate that does not match that Host.