### PR TITLE
custom domains: Specify certain types of headers to pass through

### DIFF
--- a/customdomain-terraform/modules/customdomain/main.tf
+++ b/customdomain-terraform/modules/customdomain/main.tf
@@ -86,6 +86,20 @@ resource "aws_cloudfront_distribution" "cloudfront_dist" {
       cookies {
         forward = "all"
       }
+
+      headers = [
+        "Content-Type",
+        "Referer",
+        "User-Agent",
+        "Accept",
+        "Accept-Language",
+        "Content-Length",
+        "Origin",
+        "DNT",
+        "Upgrade-Insecure-Requests",
+        "Pragma",
+        "Cache-Control"
+      ]
     }
 
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
List of headers requested by Phil Miller.

I removed Host and Connection from his list as those probably need to be
controlled by CloudFront for things to work properly.