### PR TITLE
customdomain: Remove Upgrade-Insecure-Requests header, we already enforce HTTPS

### DIFF
--- a/customdomain-terraform/modules/customdomain/main.tf
+++ b/customdomain-terraform/modules/customdomain/main.tf
@@ -96,7 +96,6 @@ resource "aws_cloudfront_distribution" "cloudfront_dist" {
         "Content-Length",
         "Origin",
         "DNT",
-        "Upgrade-Insecure-Requests",
         "Pragma",
         "Cache-Control"
       ]


### PR DESCRIPTION
And hit the default quota on whitelisted headers to pass through.