### PR TITLE
EID-1977: Add European Commission to egress safelist

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,8 @@ egressSafelist:
       # HMRC integration
       - hmrc-integration-connector.london.verify.govsvc.uk
       - test-www.tax.service.gov.uk
+      # European Commission
+      - ec.europa.eu
       # Netherlands
       - acc-eidas.minez.nl
       # Denmark


### PR DESCRIPTION
So we can connect to the EU Node Validator