### PR TITLE
Fix list-vs-set usage

### DIFF
--- a/customdomain-terraform/modules/customdomain/main.tf
+++ b/customdomain-terraform/modules/customdomain/main.tf
@@ -52,7 +52,7 @@ resource "aws_route53_record" "cert_validation" {
 resource "aws_acm_certificate_validation" "cert-validation" {
   provider                = aws.us-east-1
   certificate_arn         = aws_acm_certificate.cert.arn
-  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }
 
 resource "aws_cloudfront_distribution" "cloudfront_dist" {

--- a/customdomain-terraform/modules/customdomain/main.tf
+++ b/customdomain-terraform/modules/customdomain/main.tf
@@ -33,10 +33,19 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+
   zone_id = var.zone_id
-  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 


### PR DESCRIPTION
See also https://github.com/alphagov/verify-terraform/pull/1271

Been getting errors like:

Error: Invalid index

  on modules/customdomain/main.tf line 36, in resource "aws_route53_record" "cert_validation":
  36:   name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name

This value does not have any indices.