### PR TITLE
Allow GSP egress to Greece Prod Connector

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -121,6 +121,8 @@ egressSafelist:
       - eidas.redsara.es
       # Slovakia
       - eidas.slovensko.sk
+      # Greece
+      - eidas.gov.gr
 
     ports:
     - name: https


### PR DESCRIPTION
We need to be able to read Greece Connector node metadata from host `eidas.gov.gr`.